### PR TITLE
Add a weak memory cache to prevent image duplication after memory warnings.

### DIFF
--- a/SGImageCache.m
+++ b/SGImageCache.m
@@ -57,7 +57,12 @@ void backgroundDo(void(^block)()) {
 
 + (UIImage *)imageForURL:(NSString *)url {
     if ([UIDevice.currentDevice.systemVersion hasPrefix:@"8"]) {
-        return [UIImage imageNamed:[self.cache pathForURL:url]];
+        UIImage *weakImage = [[self.cache weakCache] objectForKey:[self.cache pathForURL:url]];
+        if(! weakImage) {
+            weakImage = [UIImage imageNamed:[self.cache pathForURL:url]];
+            [[self.cache weakCache] setObject:weakImage forKey:[self.cache pathForURL:url]];
+        }
+        return weakImage;
     }
     else {
         UIImage *weakImage = [[self.cache weakCache] objectForKey:[self.cache relativePathForURL:url]];


### PR DESCRIPTION
Consider the scenario of an image being loaded and retained by a view. Then at some point, a memory warning is fired, which causes the memory cache to be cleared. At some point later, the same image is reloaded and since it is not in the memory cache it will be reloaded either from the disk or fetched remotely once again. In either case, there are now 2 instances of the same image living in memory. 

This pull request fixes this case by maintaining a weak mapping of all dispatched images so that they can be opportunistically reused later if they are needed. No image will ever be duplicated as a result. This change would also significantly improve memory usage in https://github.com/seatgeek/SGImageCache/issues/1. For more info, I have submitted a similar pull request on SDWebImage, here: https://github.com/rs/SDWebImage/pull/791.
