### PR TITLE
Prevent CocoaPods auto-upgrading when PMK 2.0 releases

### DIFF
--- a/SGImageCache.podspec
+++ b/SGImageCache.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency "SGHTTPRequest"
   s.dependency "MGEvents"
-  s.dependency 'PromiseKit/base'
+  s.dependency 'PromiseKit/base', '~> 1.5'
 end


### PR DESCRIPTION
I will be releasing PromiseKit 2 soon (ish), probably you could just upgrade without trouble, but it seems prudent to not have this happen without you at least verifying everything is OK first.