### PR TITLE
Seems to be missing the AFNetworking dependency

### DIFF
--- a/SGImageCache.podspec
+++ b/SGImageCache.podspec
@@ -11,5 +11,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency "SGHTTPRequest"
   s.dependency "MGEvents"
+  s.dependency "AFNetworking"
   s.dependency 'PromiseKit/base'
 end


### PR DESCRIPTION
I tried installing in my swift project using Alamofire instead of AFNetworking and had to manually modify the dependency to the AfNetworking.framework in the pod project file. Will this fix it?