### PR TITLE
method for adding an image to the cache

### DIFF
--- a/SGImageCache.h
+++ b/SGImageCache.h
@@ -260,4 +260,13 @@ resolve when the existing task completes.
 
 + (NSCache *)globalMemCache;
 
+
+/** @name local setter */
+
+/**
+ * Add an image to the cache locally
+ */
++ (void)setImage:(UIImage *)image forURL:(NSString *)url;
+
+
 @end

--- a/SGImageCache.m
+++ b/SGImageCache.m
@@ -104,6 +104,25 @@
     return image;
 }
 
++ (void)setImage:(UIImage *)image forURL:(NSString *)url {
+    if ([self.globalMemCache objectForKey:url]) {
+        NSLog(@"XXX image already in global mem cache");
+        return;
+    }
+    int height = image.size.height,
+    width = image.size.width;
+    int bytesPerRow = 4 * width;
+    if (bytesPerRow % 16) {
+        bytesPerRow = ((bytesPerRow / 16) + 1) * 16;
+    }
+    NSUInteger imageCost = height * bytesPerRow;
+    NSString *cacheKey = [self.cache cacheKeyFor:url requestHeaders:nil];
+    [self.globalMemCache setObject:image forKey:cacheKey cost:imageCost];
+    NSData *data = UIImagePNGRepresentation(image);
+    [SGImageCache addData:data forCacheKey:cacheKey];
+    NSLog(@"added cacheKey XXX   %@", cacheKey);
+}
+
 + (SGCachePromise *)getImageForURL:(NSString *)url {
     return [self getImageForURL:url requestHeaders:nil];
 }


### PR DESCRIPTION
I find that when taking pictures on the device, I end up wrestling with viewing them locally until they're pushed to the server.  If I'm offline, this is impossible without dealing with this edge case specifically.  This is a convenience method for adding them to the cache locally.  