### PR TITLE
Add AllowUserInteraction to UIView animation opts

### DIFF
--- a/UIImageView+SGImageCache.m
+++ b/UIImageView+SGImageCache.m
@@ -65,7 +65,7 @@
             [UIView transitionWithView:self.superview
                               duration:duration
                                options:UIViewAnimationOptionTransitionCrossDissolve |
-             UIViewAnimationOptionAllowAnimatedContent
+             UIViewAnimationOptionAllowAnimatedContent | UIViewAnimationOptionAllowUserInteraction
                             animations:^{
                                 self.image = image;
                                 [self trigger:SGImageViewImageChanged withContext:image];
@@ -93,7 +93,7 @@
                 [UIView transitionWithView:me.superview
                                   duration:duration
                                    options:UIViewAnimationOptionTransitionCrossDissolve |
-                                           UIViewAnimationOptionAllowAnimatedContent
+                                           UIViewAnimationOptionAllowAnimatedContent | UIViewAnimationOptionAllowUserInteraction
                                 animations:^{
                                     me.image = image;
                                     [me trigger:SGImageViewImageChanged withContext:image];
@@ -120,7 +120,7 @@
         [UIView transitionWithView:me.superview
                           duration:duration
                            options:UIViewAnimationOptionTransitionCrossDissolve |
-                                   UIViewAnimationOptionAllowAnimatedContent
+                                   UIViewAnimationOptionAllowAnimatedContent | UIViewAnimationOptionAllowUserInteraction
                         animations:^{
                             me.image = image;
                             [me trigger:SGImageViewImageChanged withContext:image];


### PR DESCRIPTION
I has having some scrolling issues where some of my swipes on my tableview would be missed when using the crossFade option on:

``` objective-c
- (void)setImageForURL:(NSString *)url
           placeholder:(UIImage *)placeholder
     crossFadeDuration:(NSTimeInterval)duration
```

By default iOS disables interaction on a UIView while it is being animated.  You can add the UIViewAnimationOptionAllowUserInteraction option to allow interaction while the view is animating.

Before (missed interactions):
https://www.dropbox.com/s/hcgmt6v27dyqxu8/SGImageView-Missed-Swipes.mov?dl=0

After:
https://www.dropbox.com/s/jxqsxeq94sh7iq8/SGImageView-Fixed.mov?dl=0

Thanks for a great library!

Cheers,
Ryan
